### PR TITLE
Tie show/hide node/link labels to localstorage per assignment

### DIFF
--- a/public/js/Bridges/BridgesVisualizer.js
+++ b/public/js/Bridges/BridgesVisualizer.js
@@ -86,8 +86,8 @@
 
   //this boolean is used to deactivate the tooltip when all labels are shown (key 'L')
   BridgesVisualizer.tooltipEnabled = true;
-  BridgesVisualizer.showingNodeLabels = false;
-  BridgesVisualizer.showingLinkLabels = false;
+  BridgesVisualizer.showingNodeLabels = localStorage.getItem("showNodeLabels-"+assignmentNumber)==="true";
+  BridgesVisualizer.showingLinkLabels = localStorage.getItem("showLinkLabels-"+assignmentNumber)==="true";
 
   BridgesVisualizer.centerTextHorizontallyInRect = function(obj, width){
       return (width - obj.getComputedTextLength()) / 2;
@@ -285,6 +285,7 @@
         d3.selectAll(".nodeLabel").style("display","none").style("opacity","0");
         BridgesVisualizer.showingNodeLabels = false;
     }
+    localStorage.setItem("showNodeLabels-"+assignmentNumber, BridgesVisualizer.showingNodeLabels)
     BridgesVisualizer.redraw();
   };
 
@@ -299,6 +300,7 @@
         d3.selectAll(".selfLinkLabel").style("display", "none");
         BridgesVisualizer.showingLinkLabels = false;
     }
+    localStorage.setItem("showLinkLabels-"+assignmentNumber, BridgesVisualizer.showingLinkLabels)
     BridgesVisualizer.redraw();
   };
 


### PR DESCRIPTION
Having to repeatedly bring the labels back is bugging me a little. It'd be better if it was an actual assignment setting, or even just autodetected (if I made labels, I want them to be viewable). But at the minimum, just having them persist per assignment would be helpful.